### PR TITLE
#5098 - Added test compare id files

### DIFF
--- a/bin/conf-and-run-gerrit.sh
+++ b/bin/conf-and-run-gerrit.sh
@@ -10,7 +10,12 @@ for f in $GERRIT_SSH_PATH/*; do
    file=$(basename $f)
    DIR=$(dirname $f)
    new=$(echo $file | sed -e 's/ssh-key/id_rsa/')
-   mv "$DIR/$file" "$DIR/$new"
+ 
+   if [ "$DIR/$file" != "$DIR/$new"]; then
+       mv "$DIR/$file" "$DIR/$new"
+   else
+      echo "id files identical"
+   fi
 
    if [ "$new" = "id_rsa.pub" ]; then
       echo $DIR/$new


### PR DESCRIPTION
More luck with this test, the build and deployment is successful and I can confirm terminal login to the container via web console.

container log below:

```
 1
/bin
2
id files matchs
3
/boot
4
id files matchs
5
/dev
6
id files matchs
7
/etc
8
id files matchs
9
/home
10
id files matchs
11
/lib
12
id files matchs
13
/lib64
14
id files matchs
15
/media
16
id files matchs
17
/mnt
18
id files matchs
19
/opt
20
id files matchs
21
/proc
22
id files matchs
23
/root
24
id files matchs
25
/run
26
id files matchs
27
/sbin
28
id files matchs
29
/srv
30
id files matchs
31
/sys
32
id files matchs
33
/tmp
34
id files matchs
35
/usr
36
id files matchs
37
/var
38
id files matchs
39
>> .gerrit-configured doesn't exist. We will start gerrit to generate it
40
Generating SSH host key ... rsa(simple)... done
41
Initialized /home/gerrit/site
42
[2015-11-30 15:36:16,439] INFO  com.google.gerrit.server.git.LocalDiskRepositoryManager : Defaulting core.streamFileThreshold to 211m
43
[2015-11-30 15:36:16,803] INFO  com.google.gerrit.server.cache.h2.H2CacheFactory : Enabling disk cache /home/gerrit/site/cache
44

Reindexing changes: done    
45
Reindexed 0 changes in 0.0s (0.0/s)
46
[2015-11-30 15:36:17,365] WARN  com.google.gerrit.server.cache.h2.H2CacheImpl : Cannot build BloomFilter for jdbc:h2:file:/home/gerrit/site/cache/diff_intraline
47
org.h2.jdbc.JdbcSQLException: Error opening database: "Sleep interrupted" [8000-174]
48
    at org.h2.message.DbException.getJdbcSQLException(DbException.java:332)
49
    at org.h2.message.DbException.get(DbException.java:161)
50
    at org.h2.store.FileLock.getExceptionFatal(FileLock.java:450)
51
    at org.h2.store.FileLock.sleep(FileLock.java:445)
52
    at org.h2.store.FileLock.lockFile(FileLock.java:358)
53
    at org.h2.store.FileLock.lock(FileLock.java:133)
54
    at org.h2.engine.Database.open(Database.java:575)
55
    at org.h2.engine.Database.openDatabase(Database.java:236)
56
    at org.h2.engine.Database.<init>(Database.java:231)
57
    at org.h2.engine.Engine.openSession(Engine.java:56)
58
    at org.h2.engine.Engine.openSession(Engine.java:160)
59
    at org.h2.engine.Engine.createSessionAndValidate(Engine.java:139)
60
    at org.h2.engine.Engine.createSession(Engine.java:122)
61
    at org.h2.engine.Engine.createSession(Engine.java:28)
62
    at org.h2.engine.SessionRemote.connectEmbeddedOrServer(SessionRemote.java:323)
63
    at org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:105)
64
    at org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:90)
65
    at org.h2.Driver.connect(Driver.java:73)
66
    at com.google.gerrit.server.cache.h2.H2CacheImpl$SqlHandle.<init>(H2CacheImpl.java:636)
67
    at com.google.gerrit.server.cache.h2.H2CacheImpl$SqlStore.acquire(H2CacheImpl.java:604)
68
    at com.google.gerrit.server.cache.h2.H2CacheImpl$SqlStore.buildBloomFilter(H2CacheImpl.java:365)
69
    at com.google.gerrit.server.cache.h2.H2CacheImpl$SqlStore.open(H2CacheImpl.java:337)
70
    at com.google.gerrit.server.cache.h2.H2CacheImpl.start(H2CacheImpl.java:167)
71
    at com.google.gerrit.server.cache.h2.H2CacheFactory$1.run(H2CacheFactory.java:113)
72
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
73
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
74
    at java.lang.Thread.run(Thread.java:745)
75
Caused by: java.lang.InterruptedException: sleep interrupted
76
    at java.lang.Thread.sleep(Native Method)
77
    at org.h2.store.FileLock.sleep(FileLock.java:443)
78
    ... 23 more
79
[2015-11-30 15:36:17,366] INFO  com.google.gerrit.server.cache.h2.H2CacheFactory : Finishing 4 disk cache updates
80
>> Configure Git Replication & replace variables : GIT_SERVER_IP, GIT_SERVER_PORT, GIT_SERVER_USER, GIT_SERVER_PASSWORD & GIT_SERVER_PROJ_ROOT
81
>> Configure Git Config and change AUTH_TYPE
82
Initialized /home/gerrit/site
83
Add .gerrit-configured file
84
Launching job to update Project Config. It will wait till a connection can be established with the SSHD of Gerrit
85
Starting Gerrit ... 
86
[2015-11-30 15:36:24,376] INFO  com.google.gerrit.server.cache.h2.H2CacheFactory : Enabling disk cache /home/gerrit/site/cache
87
[2015-11-30 15:36:25,122] INFO  com.google.gerrit.server.config.ScheduleConfig : gc schedule parameter "gc.interval" is not configured
88
[2015-11-30 15:36:25,807] WARN  com.google.gerrit.httpd.GitWebConfig : gitweb not installed (no /usr/lib/cgi-bin/gitweb.cgi found)
89
[2015-11-30 15:36:26,286] INFO  org.eclipse.jetty.util.log : Logging initialized @5484ms
90
[2015-11-30 15:36:26,550] INFO  com.google.gerrit.server.git.LocalDiskRepositoryManager : Defaulting core.streamFileThreshold to 211m
91
[2015-11-30 15:36:26,566] INFO  com.google.gerrit.server.plugins.PluginLoader : Loading plugins from /home/gerrit/site/plugins
92
Nov 30, 2015 3:36:26 PM com.google.inject.servlet.GuiceFilter setPipeline
93
WARNING: Multiple Servlet injectors detected. This is a warning indicating that you have more than one GuiceFilter running in your web application. If this is deliberate, you may safely ignore this message. If this is NOT deliberate however, your application may not work as expected.
94
[2015-11-30 15:36:26,631] INFO  com.google.gerrit.server.plugins.PluginLoader : Loaded plugin create-admin-user, version 2.11.3
95
Nov 30, 2015 3:36:26 PM com.google.inject.servlet.GuiceFilter setPipeline
96
WARNING: Multiple Servlet injectors detected. This is a warning indicating that you have more than one GuiceFilter running in your web application. If this is deliberate, you may safely ignore this message. If this is NOT deliberate however, your application may not work as expected.
97
[2015-11-30 15:36:26,720] INFO  com.google.gerrit.server.plugins.PluginLoader : Loaded plugin deleteproject, version 2.11
98
[2015-11-30 15:36:26,766] INFO  com.google.gerrit.server.plugins.PluginLoader : Loaded plugin download-commands, version v2.11
99
[2015-11-30 15:36:26,832] INFO  com.google.gerrit.server.plugins.PluginLoader : Loaded plugin replication, version v2.11
100
[2015-11-30 15:36:27,456] INFO  com.google.gerrit.sshd.SshDaemon : Started Gerrit SSHD-CORE-0.14.0 on *:29418
101
[2015-11-30 15:36:27,459] INFO  org.eclipse.jetty.server.Server : jetty-9.2.9.v20150224
102
[2015-11-30 15:36:27,950] INFO  org.eclipse.jetty.server.handler.ContextHandler : Started o.e.j.s.ServletContextHandler@75211d5d{/,file:/root/.gerritcodereview/tmp/gerrit_618888882925352088_app/gerrit_war/,AVAILABLE}
103
[2015-11-30 15:36:27,954] INFO  org.eclipse.jetty.server.ServerConnector : Started ServerConnector@39fea04{HTTP/1.1}{0.0.0.0:8080}
104
[2015-11-30 15:36:27,954] INFO  org.eclipse.jetty.server.Server : Started @7153ms
105
[2015-11-30 15:36:27,955] INFO  com.google.gerrit.pgm.Daemon : Gerrit Code Review 2.11 ready
```
